### PR TITLE
Add custom scope to warning region

### DIFF
--- a/pyflakes.py
+++ b/pyflakes.py
@@ -47,7 +47,7 @@ class PyflakesListener(sublime_plugin.EventListener):
           if region:
             regions.append(region)
 
-        view.add_regions('PyflakesWarnings', regions, 'string', 'dot')
+        view.add_regions('PyflakesWarnings', regions, 'string pyflakeswarning', 'dot')
 
 
   def on_selection_modified(self, view):


### PR DESCRIPTION
This allows us to define a custom color for the warning messages in our syntax theme with something like the following:

```
<dict>
    <key>name</key><string>PyFlakes Warning</string>
    <key>scope</key><string>pyflakeswarning</string>
    <key>settings</key><dict>
        <key>foreground</key><string>#330</string>
    </dict>
</dict>
```

If this is not defined, it will degrade back to the string color as it worked originally.
